### PR TITLE
Add Jetty MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,12 +58,14 @@ To run the application:
 ## MCPServer
 
 This project also includes a simple Jetty-based `MCPServer`. It exposes an HTTP
-endpoint at `/password` that returns the string `P@ssw0rd`.
+endpoint at `/password` that returns the string `P@ssw0rd`. By default the
+server listens on port `12006`; you can override this with `-p <port>`.
 
 Run it with:
 
 ```bash
-java -cp build/classes/kotlin/main org.example.MCPServerKt
+./gradlew shadowJar
+java -cp build/libs/ContainerNursery-all.jar org.example.MCPServerKt
 ```
 
 ## TODO:

--- a/README.md
+++ b/README.md
@@ -55,6 +55,17 @@ To run the application:
     ```
     The server will start on port 8080 by default. Ensure your Docker daemon is running.
 
+## MCPServer
+
+This project also includes a simple Jetty-based `MCPServer`. It exposes an HTTP
+endpoint at `/password` that returns the string `P@ssw0rd`.
+
+Run it with:
+
+```bash
+java -cp build/classes/kotlin/main org.example.MCPServerKt
+```
+
 ## TODO:
 * Maximum concurrency limits for each instance of the docker image
 * Error reporting if the docker image never becomes available

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,10 +22,13 @@ dependencies {
     implementation("com.github.docker-java:docker-java:3.5.1")
     implementation("com.github.docker-java:docker-java-transport-httpclient5:3.5.1")
     implementation("com.google.code.gson:gson:2.10.1")
+    implementation("org.eclipse.jetty:jetty-server:11.0.17")
+    implementation("org.eclipse.jetty:jetty-servlet:11.0.17")
 
     testImplementation(platform("org.junit:junit-bom:5.10.0"))
     testImplementation("org.junit.jupiter:junit-jupiter")
-    testImplementation(kotlin("test"))
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
+    testImplementation(kotlin("test-junit5"))
     testImplementation("io.ktor:ktor-server-test-host:$ktorVersion")
     
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.0")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,10 +24,12 @@ dependencies {
     implementation("com.google.code.gson:gson:2.10.1")
     implementation("org.eclipse.jetty:jetty-server:11.0.17")
     implementation("org.eclipse.jetty:jetty-servlet:11.0.17")
+    implementation("commons-cli:commons-cli:1.6.0")
 
     testImplementation(platform("org.junit:junit-bom:5.10.0"))
     testImplementation("org.junit.jupiter:junit-jupiter")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.10.0")
     testImplementation(kotlin("test-junit5"))
     testImplementation("io.ktor:ktor-server-test-host:$ktorVersion")
     

--- a/src/main/kotlin/org/example/MCPServer.kt
+++ b/src/main/kotlin/org/example/MCPServer.kt
@@ -6,10 +6,16 @@ import org.eclipse.jetty.servlet.ServletHolder
 import jakarta.servlet.http.HttpServlet
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
+import org.apache.commons.cli.DefaultParser
+import org.apache.commons.cli.HelpFormatter
+import org.apache.commons.cli.Options
+import org.apache.commons.cli.ParseException
 
 fun getSecretPassword(): String = "P@ssw0rd"
 
-class MCPServer(private val port: Int = 0) {
+const val DEFAULT_PORT = 12006
+
+class MCPServer(private val port: Int = DEFAULT_PORT) {
     val jettyServer = Server(port)
     init {
         val context = ServletContextHandler(ServletContextHandler.NO_SESSIONS)
@@ -31,10 +37,22 @@ class MCPServer(private val port: Int = 0) {
     }
 }
 
-fun main() {
-    val server = MCPServer(8080)
+fun main(args: Array<String>) {
+    val options = Options().apply {
+        addOption("p", "port", true, "Port to listen on (default $DEFAULT_PORT)")
+    }
+
+    val parser = DefaultParser()
+    val port = try {
+        val cmd = parser.parse(options, args)
+        cmd.getOptionValue("p")?.toIntOrNull() ?: DEFAULT_PORT
+    } catch (e: ParseException) {
+        HelpFormatter().printHelp("MCPServer", options)
+        return
+    }
+
+    val server = MCPServer(port)
     server.start()
-    println("MCPServer started on port 8080")
-    server.port() // to trigger port evaluation
+    println("MCPServer started on port ${server.port()}")
     server.jettyServer.join()
 }

--- a/src/main/kotlin/org/example/MCPServer.kt
+++ b/src/main/kotlin/org/example/MCPServer.kt
@@ -1,0 +1,40 @@
+package org.example
+
+import org.eclipse.jetty.server.Server
+import org.eclipse.jetty.servlet.ServletContextHandler
+import org.eclipse.jetty.servlet.ServletHolder
+import jakarta.servlet.http.HttpServlet
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+
+fun getSecretPassword(): String = "P@ssw0rd"
+
+class MCPServer(private val port: Int = 0) {
+    val jettyServer = Server(port)
+    init {
+        val context = ServletContextHandler(ServletContextHandler.NO_SESSIONS)
+        context.contextPath = "/"
+        context.addServlet(ServletHolder(PasswordServlet()), "/password")
+        jettyServer.handler = context
+    }
+
+    fun start() { jettyServer.start() }
+    fun stop() { jettyServer.stop() }
+    fun port(): Int = (jettyServer.connectors.first() as org.eclipse.jetty.server.ServerConnector).localPort
+
+    private class PasswordServlet : HttpServlet() {
+        override fun doGet(req: HttpServletRequest, resp: HttpServletResponse) {
+            resp.status = HttpServletResponse.SC_OK
+            resp.contentType = "text/plain"
+            resp.writer.write(getSecretPassword())
+        }
+    }
+}
+
+fun main() {
+    val server = MCPServer(8080)
+    server.start()
+    println("MCPServer started on port 8080")
+    server.port() // to trigger port evaluation
+    server.jettyServer.join()
+}

--- a/src/test/kotlin/org/example/MCPServerTest.kt
+++ b/src/test/kotlin/org/example/MCPServerTest.kt
@@ -1,0 +1,23 @@
+package org.example
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MCPServerTest {
+    @Test
+    fun passwordEndpointReturnsSecret() = runBlocking {
+        val server = MCPServer(0)
+        server.start()
+        val port = server.port()
+        val client = HttpClient(CIO)
+        val response = client.get("http://localhost:$port/password").bodyAsText()
+        client.close()
+        server.stop()
+        assertEquals("P@ssw0rd", response)
+    }
+}


### PR DESCRIPTION
## Summary
- add Jetty-based MCP server returning a fixed password
- add test for new MCP server
- update README with MCP server usage
- add Jetty dependencies and JUnit 5 configuration

## Testing
- `./gradlew test --no-daemon --console=plain` *(fails: Could not start Gradle Test Executor 1: Failed to load JUnit Platform)*

------
https://chatgpt.com/codex/tasks/task_e_68729a88faa88320a36274377e5ef87a